### PR TITLE
JWU 테이블을 설명 목적으로 컬럼 추가

### DIFF
--- a/src/main/java/shurona/wordfinder/TomcatWebCustomConfig.java
+++ b/src/main/java/shurona/wordfinder/TomcatWebCustomConfig.java
@@ -9,6 +9,6 @@ public class TomcatWebCustomConfig implements WebServerFactoryCustomizer<TomcatS
 
     @Override
     public void customize(TomcatServletWebServerFactory factory) {
-        factory.addConnectorCustomizers(connector -> connector.setProperty("relaxedQueryChars", "[]"));
+//        factory.addConnectorCustomizers(connector -> connector.setProperty("relaxedQueryChars", "[]"));
     }
 }

--- a/src/main/java/shurona/wordfinder/common/DateInfoEntity.java
+++ b/src/main/java/shurona/wordfinder/common/DateInfoEntity.java
@@ -1,12 +1,14 @@
 package shurona.wordfinder.common;
 
 import jakarta.persistence.MappedSuperclass;
+import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDateTime;
 
 @MappedSuperclass
 public abstract class DateInfoEntity {
     protected LocalDateTime createdAt;
+    @UpdateTimestamp
     protected LocalDateTime updatedAt;
 
 

--- a/src/main/java/shurona/wordfinder/word/domain/JoinWordUser.java
+++ b/src/main/java/shurona/wordfinder/word/domain/JoinWordUser.java
@@ -27,6 +27,9 @@ public class JoinWordUser extends DateInfoEntity {
     @JoinColumn(name = "USER_ID")
     private User user;
 
+    private Boolean visible;
+
+    private LocalDateTime lastSelectedQuiz;
 
     public JoinWordUser() {
         //
@@ -35,6 +38,9 @@ public class JoinWordUser extends DateInfoEntity {
     public JoinWordUser(User user, Word word) {
         this.user= user;
         this.word = word;
+
+        this.visible = true;
+        this.lastSelectedQuiz = LocalDateTime.now();
 
         // 날짜 지정
         this.createdAt = LocalDateTime.now();;
@@ -60,11 +66,23 @@ public class JoinWordUser extends DateInfoEntity {
         return this.user;
     }
 
+    public Boolean getVisible() {
+        return visible;
+    }
+
+    public LocalDateTime getLastSelectedQuiz() {
+        return lastSelectedQuiz;
+    }
+
     /*
-    도메인 로직
+        도메인 로직
+     */
+
+    /**
+     * 퀴즈에 선택된 경우 날짜를 오늘로 업데이트 해준다.
      */
     public void updateDataWhenCreateQuiz() {
-        this.updatedAt = LocalDateTime.now();
+        this.lastSelectedQuiz = LocalDateTime.now();
     }
 
 

--- a/src/main/java/shurona/wordfinder/word/repository/joinuserword/DatabaseJoinWordRepository.java
+++ b/src/main/java/shurona/wordfinder/word/repository/joinuserword/DatabaseJoinWordRepository.java
@@ -60,7 +60,7 @@ public class DatabaseJoinWordRepository implements JoinWordRepository {
     @Override
     public JoinWordUser[] pickListForQuiz(Long userId, int offset, int limit) {
         String query = "select jwu from JoinWordUser as jwu join fetch jwu.word where jwu.user.id = :userId " +
-                "order by jwu.updatedAt desc";
+                "order by jwu.lastSelectedQuiz desc";
 
         List<JoinWordUser> joinWordUserList = this.em.createQuery(query, JoinWordUser.class)
                 .setParameter("userId", userId)
@@ -75,7 +75,7 @@ public class DatabaseJoinWordRepository implements JoinWordRepository {
     public JoinWordUser[] pickRandomForQuiz(Long userId, int offset, int limit) {
         String query = "select jwu from JoinWordUser as jwu " +
                 "where jwu.id in " +
-                "(select j.id from JoinWordUser as j where j.user.id = :userId order by j.updatedAt desc offset :offset)"
+                "(select j.id from JoinWordUser as j where j.user.id = :userId order by j.lastSelectedQuiz desc offset :offset)"
                 + "order by random()";
 
 //        String query = "select jwu from JoinWordUser as jwu where jwu.user.id = :userId order by jwu.updatedAt";


### PR DESCRIPTION
변경 사항
- 퀴즈 선택 시 최근 날짜를 updateAt column을 두 가지로 분리
- 유저가 숨김 설정할 수 있도록 컬럼 하나 추가

테이블 변경 쿼리
```
alter table if exists join_word_user
       add column last_selected_quiz timestamp(6)

    alter table if exists join_word_user
       add column visible boolean
```
